### PR TITLE
fix: parse invalid lyric timestamp failed (#938)

### DIFF
--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -184,7 +184,7 @@ class Ui(object):
 
     def update_lyrics(self, now_playing, lyrics, tlyrics):
 
-        timestap_regex = r"\d\d:\d\d\.[0-9]*"
+        timestap_regex = r"[0-5][0-9]:[0-5][0-9]\.[0-9]*"
 
         def get_timestap(lyric_line):
             match_ret = re.match(r"\[(" + timestap_regex + r")\]", lyric_line)


### PR DESCRIPTION
Time string from lyric_line is invalid in some case
For example, '99:00.00' which does not match format '%M:%S.%f'

fix #936

Signed-off-by: hoyho <luohaihao@gmail.com>